### PR TITLE
Fix namespace path in autoload config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     {
       "name": "Jan-Marten de Boer",
       "email": "github@johmanx.com",
-      "homepage": "http://johmanx.com",
       "role": "developer"
     }
   ],
@@ -25,7 +24,7 @@
       "registration.php"
     ],
     "psr-4": {
-      "VendorName\\MyModule\\": "src/Hackathon/AddressValidation/"
+      "Hackathon\\AddressValidation\\": ""
     }
   }
 }


### PR DESCRIPTION
You'll need this if you want to prevent a deep namespace directory structure. PSR-4 allows to use a directory structure that is not a one-to-one relation with your namespaces.

E.g.: `Hackathon\AddressValidation\Foo\Bar` as class.

Would have to reside in `src/Hackathon/AddressValidation/Foo/Bar.php`

And can now reside in `Foo/Bar.php`